### PR TITLE
Make command line argument handling clean and explicit.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Release Notes
 
 *November 10, 2016*
 
+1.5.26a
+-------
+- Add Algo.with_cmd_args() factory to handle command line arguments cleanly and explicitly.
+- Call Algo.on_start() from run() rather than __init__() so fields set in __init__ are available
+  to on_start() in subclasses.
+
 1.5.25a
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,7 @@ While the Blotter running in the background, write and execute your algorithm:
 
 
     if __name__ == "__main__":
-        strategy = CrossOver(
+        strategy = CrossOver.with_cmd_args(
             instruments = [ ("ES", "FUT", "GLOBEX", "USD", 201609, 0.0, "") ], # ib tuples
             resolution  = "1T", # Pandas resolution (use "K" for tick bars)
             tick_window = 20, # no. of ticks to keep

--- a/docs/source/algo.rst
+++ b/docs/source/algo.rst
@@ -154,7 +154,7 @@ While the Blotter running in the background, write and execute your algorithm:
 
 
     if __name__ == "__main__":
-        strategy = CrossOver(
+        strategy = CrossOver.with_cmd_args(
             instruments = [ ("CL", "FUT", "NYMEX", "USD", 201609) ],
             resolution  = "1H"
         )
@@ -169,8 +169,8 @@ With your Blotter running in the background, run your algo from the command line
     $ python strategy.py --log ~/qtpy/
 
 
-By adding ``--log ~/qtpy/`` we ask that the resulting trade journal be saved
-in ``~/qtpy/STRATEGY_YYYYMMDD.csv`` for later analysis **in additioan** to
+By adding ``.with_cmd_args()`` and running with ``--log ~/qtpy/`` we ask that the resulting trade journal be saved
+in ``~/qtpy/STRATEGY_YYYYMMDD.csv`` for later analysis **in addition** to
 being saved in the database.
 
 -----
@@ -247,7 +247,9 @@ Available Arguments
 -------------------
 
 Below are all the parameters that can either be set via the ``Algo()``
-or via CLI (**all are optional**).
+or via CLI (**all are optional**).  To have your algorithm use command line parameters,
+use the ``with_cmd_args()`` factory, which works just like the constructor
+but overrides any kwargs with command line args.
 
 Algo Parameters
 ~~~~~~~~~~~~~~~
@@ -268,7 +270,7 @@ Algo Parameters
     # strategy.py
     ...
 
-    strategy = MyStrategy(
+    strategy = MyStrategy.with_cmd_args(
         instruments = [ "AAPL" ],
         resolution  = "512K", # 512 tick bars
         tick_window = 10, # keep last 10 ticks bars

--- a/docs/source/api_algo.rst
+++ b/docs/source/api_algo.rst
@@ -22,6 +22,6 @@ For example:
 
 
 .. autoclass:: qtpylib.algo.Algo
-    :members: run, on_start, on_quote, on_tick, on_bar, on_fill, record, sms, get_instrument, order, cancel_order, get_history
+    :members: run, on_start, on_quote, on_tick, on_bar, on_fill, record, sms, get_instrument, order, cancel_order, get_history, with_cmd_args
     :member-order: bysource
     :noindex:

--- a/examples/strategy.py
+++ b/examples/strategy.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
     ACTIVE_MONTH = futures.get_active_contract("ES")
     print("Active month for ES is:", ACTIVE_MONTH)
 
-    strategy = TestStrategy(
+    strategy = TestStrategy.with_cmd_args(
         instruments = [ ("ES", "FUT", "GLOBEX", "USD", ACTIVE_MONTH, 0.0, "") ],
         resolution  = "1T",
         tick_window = 10,

--- a/examples/symbols.csv
+++ b/examples/symbols.csv
@@ -1,2 +1,4 @@
 symbol,sec_type,exchange,currency,expiry,strike,opt_type
-ES,FUT,GLOBEX,USD,201609.0,0.0,
+ES,FUT,GLOBEX,USD,201612.0,0.0,
+AAPL,STK,SMART,USD,,0.0,
+ES,FUT,GLOBEX,USD,201612.0,0.0,


### PR DESCRIPTION
Instead of `Algo()` implicitly incorporating command-line arguments,
this introduces an `Algo.with_cmd_args()` factory that works just like
`__init__` (takes kwargs and returns a new `Algo`) but also overrides the
kwargs with any command line arguments given.

`Algo.__init__()` takes in all possible arguments as kwargs instead of
silently setting some internally.  `Algo.with_cmd_args()` parses the
command line and forwards any (non-default) args to `__init__`.

This also moves the call of `Algo.on_start()` from `__init__()` to `run()`,
because otherwise a field set in a subclass wouldn't happen until
after `on_start()`, and it's surprising to have interface methods called before
your constructor has finished.