### PR TITLE
Fix cmd line processing (again) to respect programmatic args.

### DIFF
--- a/qtpylib/tools.py
+++ b/qtpylib/tools.py
@@ -32,6 +32,8 @@ from dateutil.relativedelta import relativedelta, FR
 from dateutil.parser import parse as parse_date
 from pytz import timezone
 
+from ezibpy.utils import create_logger      # For re-export
+
 
 # =============================================
 def chmod(f):
@@ -544,7 +546,8 @@ class RecurringTask(threading.Thread):
             start = time.time()
             self._func()
             self._functime += self.interval_sec
-            time.sleep(self._functime - start)
+            if self._functime - start > 0:
+                time.sleep(self._functime - start)
 
     def stop(self):
         """Stop the recurring task."""


### PR DESCRIPTION
Pass all params to Algo.__init__(); override with (non-default) cmd line args.
Call on_start() from Algo.run(), not the constructor, so fields set in the constructor are available in on_start().
Fix RecurringTask sleeping negative time if task took too long.
Configure logging for algo and broker; use config function from ezibpy.
Log creating and placing orders, warn when not submitting due to pending order.
Relies on ranaroussi/ezibpy#6

Remaining issue: If there are invalid orders pending, they don't get cleared out,
and no further orders can be issued.