### PR TITLE
Fixed timezone issues when using a local timezone in algorithm

### DIFF
--- a/qtpylib/algo.py
+++ b/qtpylib/algo.py
@@ -709,7 +709,7 @@ class Algo(Broker):
                 self.ticks = self._thread_safe_merge(symbol, self.ticks, self_ticks) # assign back
         else:
             self.ticks = self._update_window(self.ticks, tick)
-            bars = tools.resample(self.ticks, self.resolution)
+            bars = tools.resample(self.ticks, self.resolution, tz=self.timezone)
 
             if len(bars.index) > self.tick_bar_count > 0 or stale_tick:
                 self.record_ts = tick.index[0]

--- a/qtpylib/tools.py
+++ b/qtpylib/tools.py
@@ -557,7 +557,7 @@ def resample(data, resolution="1T", tz=None, ffill=True, dropna=False, sync_last
                 # force same last timestamp to all symbols before resampling
                 if sync_last_timestamp:
                     last_row = data[data['symbol']==sym][-1:]
-                    last_row.index = pd.to_datetime(data.index[-1:], utc=True)
+                    last_row.index = data.index[-1:]
                     if "last" not in data.columns:
                         last_row["open"]   = last_row["close"]
                         last_row["high"]   = last_row["close"]


### PR DESCRIPTION
When using a local timezone in an algorithm, the index in the resampler function in tools.py is not interpreted as a pandas.DateTimeIndex and the bar resampler breaks.

It can be tested with any strategy that specifies a timezone, such as:

    strategy =TestStrategy(
        instruments = [ ("EUR", "CASH", "IDEALPRO", "USD") ],
        timezone = "Europe/Berlin",
        resolution  = "1S",
        tick_window = 10,
        bar_window  = 10
    )