### PR TITLE
fixing bug in ATR indicator

### DIFF
--- a/qtpylib/indicators.py
+++ b/qtpylib/indicators.py
@@ -213,8 +213,7 @@ def atr(bars, window=14, exp=False):
     else:
         res = rolling_mean(tr, window)
 
-    res = pd.Series(res)
-    return (res.shift(1) * (window - 1) + res) / window
+    return pd.Series(res)
 
 
 # ---------------------------------------------


### PR DESCRIPTION
In the current implementation of ATR, the RSI-style MA (RMA) is incorrectly applied to the results of the SMA or EMA smothing of TR. Only SMA or EMA smoothing should be used.

How to see the differences: compare, for example, with tradingsview results:
* On tradingview, I used ETHBTC from Binance, 1h timeframe, set Length=14, Smoothing=SMA or EMA in the settings of built-in ATR indicator.
* With qtpylib's atr() it corresponds to window=14, exp=False or True respectively.

With the change in this PR, the results are identical.

P,S. RMA may later be added as third smoothing method to atr(). This needs changing interface to introduce the kind ("sma", "ema", "rma") parameter instead of current exp parameter.
P.P.S. RMA itself can later be added as an indicator to indicators.py
