### PR TITLE
Fix implementation of rolling_max

### DIFF
--- a/qtpylib/indicators.py
+++ b/qtpylib/indicators.py
@@ -288,9 +288,9 @@ def rolling_min(series, window=14, min_periods=None):
 def rolling_max(series, window=14, min_periods=None):
     min_periods = window if min_periods is None else min_periods
     try:
-        return series.rolling(window=window, min_periods=min_periods).min()
+        return series.rolling(window=window, min_periods=min_periods).max()
     except Exception as e:
-        return pd.Series(series).rolling(window=window, min_periods=min_periods).min()
+        return pd.Series(series).rolling(window=window, min_periods=min_periods).max()
 
 
 # ---------------------------------------------


### PR DESCRIPTION
the implementation of `rolling_max()` seems to be a copy of `rolling_min()` - including using `.min()` instead of `.max()`.

