### PR TITLE
Allow crossed() methods with np.integer types

### DIFF
--- a/qtpylib/indicators.py
+++ b/qtpylib/indicators.py
@@ -222,7 +222,7 @@ def crossed(series1, series2, direction=None):
     if isinstance(series1, np.ndarray):
         series1 = pd.Series(series1)
 
-    if isinstance(series2, (float, int, np.ndarray, np.integer)):
+    if isinstance(series2, (float, int, np.ndarray, np.integer, np.floating)):
         series2 = pd.Series(index=series1.index, data=series2)
 
     if direction is None or direction == "above":

--- a/qtpylib/indicators.py
+++ b/qtpylib/indicators.py
@@ -222,7 +222,7 @@ def crossed(series1, series2, direction=None):
     if isinstance(series1, np.ndarray):
         series1 = pd.Series(series1)
 
-    if isinstance(series2, (float, int, np.ndarray)):
+    if isinstance(series2, (float, int, np.ndarray, np.integer)):
         series2 = pd.Series(index=series1.index, data=series2)
 
     if direction is None or direction == "above":


### PR DESCRIPTION
Fixes bad behaviour when passing in a `np.integer` type instead of a regular integer
`crossed_above(series, 25)` does work, while `crossed_above(series, np.int64(25))` does not work.

Obviously, np.floating uses the same, but for floating point operators.

On it's own, this is not a problem as you can pick how to create the integer, however, it can become a problem depending where the 2nd variable came from, for example if it comes from a ml library