### PR TITLE
fixed error with changing "or" to "|"

### DIFF
--- a/qtpylib/indicators.py
+++ b/qtpylib/indicators.py
@@ -234,7 +234,7 @@ def crossed(series1, series2, direction=None):
             series1.shift(1) >= series2.shift(1)))
 
     if direction is None:
-        return above or below
+        return above | below
 
     return above if direction == "above" else below
 


### PR DESCRIPTION
when I run this qtpylib.crossed(DFIND, DFCRS)

i get this error:
2021-05-09 13:03:54,424 - freqtrade - ERROR - Fatal exception!
joblib.externals.loky.process_executor._RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/externals/loky/process_executor.py", line 431, in _process_worker
    r = call_item()
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/externals/loky/process_executor.py", line 285, in __call__
    return self.fn(*self.args, **self.kwargs)
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/_parallel_backends.py", line 595, in __call__
    return self.func(*args, **kwargs)
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/parallel.py", line 262, in __call__
    return [func(*args, **kwargs)
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/parallel.py", line 262, in <listcomp>
    return [func(*args, **kwargs)
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/externals/loky/cloudpickle_wrapper.py", line 38, in __call__
    return self._obj(*args, **kwargs)
  File "/home/mab/freqtrade/freqtrade/optimize/hyperopt.py", line 274, in generate_optimizer
    bt_results = self.backtesting.backtest(
  File "/home/mab/freqtrade/freqtrade/optimize/backtesting.py", line 354, in backtest
    data: Dict = self._get_ohlcv_as_lists(processed)
  File "/home/mab/freqtrade/freqtrade/optimize/backtesting.py", line 196, in _get_ohlcv_as_lists
    self.strategy.advise_buy(pair_data, {'pair': pair}), {'pair': pair})[headers].copy()
  File "/home/mab/freqtrade/user_data/hyperopts/GodStraHo.py", line 122, in populate_buy_trend
  File "/home/mab/freqtrade/freqtrade/vendor/qtpylib/indicators.py", line 238, in crossed
    return above or below
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/pandas/core/generic.py", line 1442, in __nonzero__
    raise ValueError(
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/mab/freqtrade/freqtrade/main.py", line 37, in main
    return_code = args['func'](args)
  File "/home/mab/freqtrade/freqtrade/commands/optimize_commands.py", line 86, in start_hyperopt
    hyperopt.start()
  File "/home/mab/freqtrade/freqtrade/optimize/hyperopt.py", line 426, in start
    f_val = self.run_optimizer_parallel(parallel, asked, i)
  File "/home/mab/freqtrade/freqtrade/optimize/hyperopt.py", line 341, in run_optimizer_parallel
    return parallel(delayed(
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/parallel.py", line 1054, in __call__
    self.retrieve()
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/parallel.py", line 933, in retrieve
    self._output.extend(job.get(timeout=self.timeout))
  File "/home/mab/freqtrade/.env/lib/python3.8/site-packages/joblib/_parallel_backends.py", line 542, in wrap_future_result
    return future.result(timeout=timeout)
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 388, in __get_result
    raise self._exception
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().